### PR TITLE
Changed DelsysFile.m "GetAllData" function

### DIFF
--- a/File Reading Examples/MATLAB API/DelsysFile.m
+++ b/File Reading Examples/MATLAB API/DelsysFile.m
@@ -27,13 +27,10 @@ classdef DelsysFile < handle
         %Return all of the data from all sensor/component channels%
         
             componentCount = obj.ComponentCount();
-            data = {};
+            data = cell(componentCount,1);
             for i = 1:componentCount
-                component = Component(i);
-                componentData = component.GetAllData();
-                for j = 1:length(componentData)
-                    data{i} = componentData{j};
-                end
+                component = obj.Component(i);
+                data{i} = component.GetAllData();
             end
         end
     


### PR DESCRIPTION
Changed "GetAllData" function in order to return a cell array of all the components' (i.e. sensors) data, moreover it returned an error for the missing "obj.". I think the intention was to concatenate channels of all components, but I'm not sure. The modification I made preserves component separation.